### PR TITLE
feat: added balance ₿-only format(bip177)

### DIFF
--- a/BDKSwiftExampleWallet/Extensions/Int+Extensions.swift
+++ b/BDKSwiftExampleWallet/Extensions/Int+Extensions.swift
@@ -34,6 +34,16 @@ extension UInt64 {
 }
 
 extension UInt64 {
+    private var numberFormatter: NumberFormatter {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.usesGroupingSeparator = true
+        numberFormatter.groupingSeparator = ","
+        numberFormatter.generatesDecimalNumbers = false
+        
+        return numberFormatter
+    }
+    
     func formattedSatoshis() -> String {
         if self == 0 {
             return "0.00 000 000"
@@ -62,15 +72,10 @@ extension UInt64 {
     func formattedBip177() -> String {
         if self >= 1_000_000 && self % 1_000_000 == .zero {
             return "\(self / 1_000_000)M"
+            
         } else if self % 1_000 == 0 {
             return "\(self / 1_000)K"
         }
-        
-        let numberFormatter = NumberFormatter()
-        numberFormatter.numberStyle = .decimal
-        numberFormatter.usesGroupingSeparator = true
-        numberFormatter.groupingSeparator = ","
-        numberFormatter.generatesDecimalNumbers = false
         
         return numberFormatter.string(from: NSNumber(value: self)) ?? "0"
     }

--- a/BDKSwiftExampleWallet/Extensions/Int+Extensions.swift
+++ b/BDKSwiftExampleWallet/Extensions/Int+Extensions.swift
@@ -70,10 +70,10 @@ extension UInt64 {
     }
     
     func formattedBip177() -> String {
-        if self >= 1_000_000 && self % 1_000_000 == .zero {
+        if self != .zero && self >= 1_000_000 && self % 1_000_000 == .zero {
             return "\(self / 1_000_000)M"
             
-        } else if self % 1_000 == 0 {
+        } else if self != .zero && self % 1_000 == 0 {
             return "\(self / 1_000)K"
         }
         

--- a/BDKSwiftExampleWallet/Extensions/Int+Extensions.swift
+++ b/BDKSwiftExampleWallet/Extensions/Int+Extensions.swift
@@ -58,6 +58,22 @@ extension UInt64 {
             return formattedBalance
         }
     }
+    
+    func formattedBip177() -> String {
+        if self >= 1_000_000 && self % 1_000_000 == .zero {
+            return "\(self / 1_000_000)M"
+        } else if self % 1_000 == 0 {
+            return "\(self / 1_000)K"
+        }
+        
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.usesGroupingSeparator = true
+        numberFormatter.groupingSeparator = ","
+        numberFormatter.generatesDecimalNumbers = false
+        
+        return numberFormatter.string(from: NSNumber(value: self)) ?? "0"
+    }
 }
 
 extension Int {

--- a/BDKSwiftExampleWallet/Model/BalanceDisplayFormat.swift
+++ b/BDKSwiftExampleWallet/Model/BalanceDisplayFormat.swift
@@ -13,12 +13,13 @@ enum BalanceDisplayFormat: String, CaseIterable, Codable {
     case sats = "sats"
     case bip21q = "bip21q"
     case fiat = "usd"
+    case bip177 = "bip177"
 
     var displayText: String {
         switch self {
         case .sats, .bitcoinSats: return "sats"
-        case .bitcoin: return ""
-        case .bip21q: return "₿"
+        case .bitcoin, .bip177: return ""
+        case .bip21q : return "₿"
         case .fiat: return "USD"
         }
     }

--- a/BDKSwiftExampleWallet/Model/BalanceDisplayFormat.swift
+++ b/BDKSwiftExampleWallet/Model/BalanceDisplayFormat.swift
@@ -19,7 +19,7 @@ enum BalanceDisplayFormat: String, CaseIterable, Codable {
         switch self {
         case .sats, .bitcoinSats: return "sats"
         case .bitcoin, .bip177: return ""
-        case .bip21q : return "₿"
+        case .bip21q: return "₿"
         case .fiat: return "USD"
         }
     }

--- a/BDKSwiftExampleWallet/View/Home/BalanceView.swift
+++ b/BDKSwiftExampleWallet/View/Home/BalanceView.swift
@@ -48,6 +48,8 @@ struct BalanceView: View {
             return balance.formatted(.number)
         case .fiat:
             return satsPrice.formatted(.number.precision(.fractionLength(2)))
+        case .bip177:
+            return balance.formattedBip177()
         }
     }
 

--- a/BDKSwiftExampleWalletTests/Extensions/BDKSwiftExampleWalletInt+Extensions.swift
+++ b/BDKSwiftExampleWalletTests/Extensions/BDKSwiftExampleWalletInt+Extensions.swift
@@ -31,4 +31,49 @@ final class BDKSwiftExampleWalletInt_Extensions: XCTestCase {
         XCTAssertEqual(tenBTC, "10.00 000 001")
     }
 
+    func testBip177() {
+        let oneHundred = UInt64(100).formattedBip177()
+        print(oneHundred)
+        XCTAssertEqual(oneHundred, "100")
+        
+        let oneThousand = UInt64(1000).formattedBip177()
+        print(oneThousand)
+        XCTAssertEqual(oneThousand, "1K")
+        
+        let oneThousandOne = UInt64(1001).formattedBip177()
+        print(oneThousandOne)
+        XCTAssertEqual(oneThousandOne, "1,001")
+        
+        let tenThousand = UInt64(10000).formattedBip177()
+        print(tenThousand)
+        XCTAssertEqual(tenThousand, "10K")
+        
+        let tenThousandOne = UInt64(10001).formattedBip177()
+        print(tenThousandOne)
+        XCTAssertEqual(tenThousandOne, "10,001")
+        
+        let oneHundredThousand = UInt64(100000).formattedBip177()
+        print(oneHundredThousand)
+        XCTAssertEqual(oneHundredThousand, "100K")
+        
+        let oneHundredThousandOne = UInt64(100001).formattedBip177()
+        print(oneHundredThousandOne)
+        XCTAssertEqual(oneHundredThousandOne, "100,001")
+        
+        let oneMillion = UInt64(1000000).formattedBip177()
+        print(oneMillion)
+        XCTAssertEqual(oneMillion, "1M")
+        
+        let oneMillionOne = UInt64(1000001).formattedBip177()
+        print(oneMillionOne)
+        XCTAssertEqual(oneMillionOne, "1,000,001")
+        
+        let treeMillions = UInt64(325_000_000).formattedBip177()
+        print(treeMillions)
+        XCTAssertEqual(treeMillions, "325M")
+        
+        let treeMillionsOne = UInt64(325_000_001).formattedBip177()
+        print(treeMillionsOne)
+        XCTAssertEqual(treeMillionsOne, "325,000,001")
+    }
 }

--- a/BDKSwiftExampleWalletTests/Extensions/BDKSwiftExampleWalletInt+Extensions.swift
+++ b/BDKSwiftExampleWalletTests/Extensions/BDKSwiftExampleWalletInt+Extensions.swift
@@ -33,47 +33,36 @@ final class BDKSwiftExampleWalletInt_Extensions: XCTestCase {
 
     func testBip177() {
         let oneHundred = UInt64(100).formattedBip177()
-        print(oneHundred)
         XCTAssertEqual(oneHundred, "100")
         
         let oneThousand = UInt64(1000).formattedBip177()
-        print(oneThousand)
         XCTAssertEqual(oneThousand, "1K")
         
         let oneThousandOne = UInt64(1001).formattedBip177()
-        print(oneThousandOne)
         XCTAssertEqual(oneThousandOne, "1,001")
         
         let tenThousand = UInt64(10000).formattedBip177()
-        print(tenThousand)
         XCTAssertEqual(tenThousand, "10K")
         
         let tenThousandOne = UInt64(10001).formattedBip177()
-        print(tenThousandOne)
         XCTAssertEqual(tenThousandOne, "10,001")
         
         let oneHundredThousand = UInt64(100000).formattedBip177()
-        print(oneHundredThousand)
         XCTAssertEqual(oneHundredThousand, "100K")
         
         let oneHundredThousandOne = UInt64(100001).formattedBip177()
-        print(oneHundredThousandOne)
         XCTAssertEqual(oneHundredThousandOne, "100,001")
         
         let oneMillion = UInt64(1000000).formattedBip177()
-        print(oneMillion)
         XCTAssertEqual(oneMillion, "1M")
         
         let oneMillionOne = UInt64(1000001).formattedBip177()
-        print(oneMillionOne)
         XCTAssertEqual(oneMillionOne, "1,000,001")
         
         let treeMillions = UInt64(325_000_000).formattedBip177()
-        print(treeMillions)
         XCTAssertEqual(treeMillions, "325M")
         
         let treeMillionsOne = UInt64(325_000_001).formattedBip177()
-        print(treeMillionsOne)
         XCTAssertEqual(treeMillionsOne, "325,000,001")
     }
 }


### PR DESCRIPTION
### Description

This PR added ₿-only format on balance screen view and resolve the [issue](https://github.com/bitcoindevkit/BDKSwiftExampleWallet/issues/298)

Reference
https://bitcoin.design/guide/designing-products/units-and-symbols/#sample-mockups

### Screens
<img width="400" height="867" alt="Simulator Screenshot - iPhone 15 Pro - 2025-07-11 at 13 02 18" src="https://github.com/user-attachments/assets/a42597c0-c148-48e5-be4f-39b17f6a99d9" />
<img width="400" height="867" alt="Simulator Screenshot - iPhone 15 Pro - 2025-07-11 at 13 15 17" src="https://github.com/user-attachments/assets/bc7a0afd-951b-4ce8-8835-bc81a2b2b7e8" />
<img width="400" height="867" alt="Simulator Screenshot - iPhone 15 Pro - 2025-07-11 at 13 15 45" src="https://github.com/user-attachments/assets/15c338e4-8015-4997-8dbf-ab8797b40a94" />

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I have formatted my code with [swift-format](https://github.com/apple/swift-format) per `.swift-format` [file](https://github.com/reez/BDKSwiftExampleWallet/blob/main/.swift-format)

#### New Features:

* [X] I've added tests for the new feature
* [ ] ~~I've added docs for the new feature~~
* [X] UI changes tested on small, medium, and large devices to ensure layout consistency