### PR TITLE
fix: balance overflow

### DIFF
--- a/BDKSwiftExampleWallet/Extensions/Int+Extensions.swift
+++ b/BDKSwiftExampleWallet/Extensions/Int+Extensions.swift
@@ -38,22 +38,28 @@ extension UInt64 {
         if self == 0 {
             return "0.00 000 000"
         } else {
-            let balanceString = String(format: "%010d", self)
-
-            let zero = balanceString.prefix(2)
-            let first = balanceString.dropFirst(2).prefix(2)
-            let second = balanceString.dropFirst(4).prefix(3)
-            let third = balanceString.dropFirst(7).prefix(3)
-
-            var formattedZero = zero
-
-            if zero == "00" {
-                formattedZero = zero.dropFirst()
-            } else if zero.hasPrefix("0") {
-                formattedZero = zero.suffix(1)
-            }
-
-            let formattedBalance = "\(formattedZero).\(first) \(second) \(third)"
+            // Convert satoshis to BTC (1 BTC = 100,000,000 sats)
+            let btcValue = Double(self) / 100_000_000.0
+            
+            // Format BTC value to exactly 8 decimal places
+            let btcString = String(format: "%.8f", btcValue)
+            
+            // Split the string at the decimal point
+            let parts = btcString.split(separator: ".")
+            guard parts.count == 2 else { return btcString }
+            
+            let wholePart = String(parts[0])
+            let decimalPart = String(parts[1])
+            
+            // Ensure decimal part is exactly 8 digits
+            let paddedDecimal = decimalPart.padding(toLength: 8, withPad: "0", startingAt: 0)
+            
+            // Format as XX.XX XXX XXX
+            let first = paddedDecimal.prefix(2)
+            let second = paddedDecimal.dropFirst(2).prefix(3)
+            let third = paddedDecimal.dropFirst(5).prefix(3)
+            
+            let formattedBalance = "\(wholePart).\(first) \(second) \(third)"
 
             return formattedBalance
         }


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

When a balance is 9,999,709,517 sats (10 digits) the format string was causing an integer overflow because %d expects a 32-bit integer but our value exceeds the maximum 32-bit integer (2,147,483,647).

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I have formatted my code with [swift-format](https://github.com/apple/swift-format) per `.swift-format` [file](https://github.com/reez/BDKSwiftExampleWallet/blob/main/.swift-format)

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] UI changes tested on small, medium, and large devices to ensure layout consistency

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
