### PR TITLE
feat(wip): sub 1 sat fee

### DIFF
--- a/BDKSwiftExampleWallet/View Model/Send/BuildTransactionViewModel.swift
+++ b/BDKSwiftExampleWallet/View Model/Send/BuildTransactionViewModel.swift
@@ -25,16 +25,26 @@ class BuildTransactionViewModel {
     }
 
     func buildTransaction(address: String, amount: UInt64, feeRate: UInt64) {
+        print("[BuildTransactionViewModel.buildTransaction] Called with:")
+        print("  - Address: \(address)")
+        print("  - Amount: \(amount) sats")
+        print("  - FeeRate: \(feeRate) sat/vB")
+        
         do {
             let txBuilderResult = try bdkClient.buildTransaction(address, amount, feeRate)
             self.psbt = txBuilderResult
+            print("[BuildTransactionViewModel.buildTransaction] PSBT created successfully")
         } catch let error as WalletError {
+            print("[BuildTransactionViewModel.buildTransaction] WalletError: \(error.localizedDescription)")
             self.buildTransactionViewError = .generic(message: error.localizedDescription)
             self.showingBuildTransactionViewErrorAlert = true
         } catch let error as AddressParseError {
+            print("[BuildTransactionViewModel.buildTransaction] AddressParseError: \(error.localizedDescription)")
             self.buildTransactionViewError = .generic(message: error.localizedDescription)
             self.showingBuildTransactionViewErrorAlert = true
         } catch {
+            print("[BuildTransactionViewModel.buildTransaction] Unknown error: \(error.localizedDescription)")
+            print("[BuildTransactionViewModel.buildTransaction] Error type: \(type(of: error))")
             self.buildTransactionViewError = .generic(message: error.localizedDescription)
             self.showingBuildTransactionViewErrorAlert = true
         }
@@ -69,22 +79,33 @@ class BuildTransactionViewModel {
     }
 
     func send(address: String, amount: UInt64, feeRate: UInt64) {
+        print("[BuildTransactionViewModel.send] Called with:")
+        print("  - Address: \(address)")
+        print("  - Amount: \(amount) sats")
+        print("  - FeeRate: \(feeRate) sat/vB")
+        
         do {
             try bdkClient.send(address, amount, feeRate)
+            print("[BuildTransactionViewModel.send] Transaction sent successfully!")
             NotificationCenter.default.post(
                 name: Notification.Name("TransactionSent"),
                 object: nil
             )
         } catch let error as EsploraError {
+            print("[BuildTransactionViewModel.send] EsploraError: \(error.localizedDescription)")
             self.buildTransactionViewError = .generic(message: error.localizedDescription)
             self.showingBuildTransactionViewErrorAlert = true
         } catch let error as SignerError {
+            print("[BuildTransactionViewModel.send] SignerError: \(error.localizedDescription)")
             self.buildTransactionViewError = .generic(message: error.localizedDescription)
             self.showingBuildTransactionViewErrorAlert = true
         } catch let error as WalletError {
+            print("[BuildTransactionViewModel.send] WalletError: \(error.localizedDescription)")
             self.buildTransactionViewError = .generic(message: error.localizedDescription)
             self.showingBuildTransactionViewErrorAlert = true
         } catch {
+            print("[BuildTransactionViewModel.send] Unknown error: \(error.localizedDescription)")
+            print("[BuildTransactionViewModel.send] Error type: \(type(of: error))")
             self.buildTransactionViewError = .generic(message: error.localizedDescription)
             self.showingBuildTransactionViewErrorAlert = true
         }

--- a/BDKSwiftExampleWallet/View/Send/BuildTransactionView.swift
+++ b/BDKSwiftExampleWallet/View/Send/BuildTransactionView.swift
@@ -118,6 +118,10 @@ struct BuildTransactionView: View {
                     if !isSent {
                         Button {
                             if let amt = UInt64(amount) {
+                                print("[BuildTransactionView] Send button pressed with:")
+                                print("  - Address: \(address)")
+                                print("  - Amount: \(amt) sats")
+                                print("  - Fee: \(fee) sat/vB")
                                 viewModel.buildTransactionViewError = nil
                                 isError = false
                                 viewModel.send(
@@ -208,13 +212,20 @@ struct BuildTransactionView: View {
             .padding()
             .navigationTitle("Transaction")
             .onAppear {
+                print("[BuildTransactionView.onAppear] View appeared with:")
+                print("  - Address: \(address)")
+                print("  - Amount: \(amount) sats")
+                print("  - Fee: \(fee) sat/vB")
                 viewModel.buildTransaction(
                     address: address,
                     amount: UInt64(amount) ?? 0,
                     feeRate: UInt64(fee)
                 )
                 if let tx = viewModel.extractTransaction() {
+                    print("[BuildTransactionView.onAppear] Extracted transaction, calculating fee")
                     viewModel.getCalulateFee(tx: tx)
+                } else {
+                    print("[BuildTransactionView.onAppear] Failed to extract transaction")
                 }
             }
             .alert(isPresented: $viewModel.showingBuildTransactionViewErrorAlert) {


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Test support for sub 1 sat fees.

### Notes to the reviewers

`FeeRate` supports https://docs.rs/bitcoin-units/0.1.2/bitcoin_units/fee_rate/struct.FeeRate.html

Needed to update a method in BDKService. 

(hardcoded fee for testing)

If I did 0.5, I got `sendrawtransaction RPC error: {"code":-26,"message":"min relay fee not
  met, 72 < 142"}`
  
So then I went to 0.99 (worked but is within current policy so not surprising) https://mempool.space/testnet4//tx/fa7e423f5cdebf1b1d5c1efa67aaed4350ec0fb6347200398f4f678b9256957f

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I have formatted my code with [swift-format](https://github.com/apple/swift-format) per `.swift-format` [file](https://github.com/reez/BDKSwiftExampleWallet/blob/main/.swift-format)

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] UI changes tested on small, medium, and large devices to ensure layout consistency

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
