### PR TITLE
feat: add kyoto retry (option 1)

### DIFF
--- a/BDKSwiftExampleWallet/View Model/WalletViewModel.swift
+++ b/BDKSwiftExampleWallet/View Model/WalletViewModel.swift
@@ -270,4 +270,13 @@ class WalletViewModel {
             await startSyncWithProgress()
         }
     }
+
+    /// Retry sync pipeline for Kyoto when a prior attempt failed.
+    func retryKyotoSync() async {
+        guard isKyotoClient else { return }
+        await syncOrFullScan()
+        getBalance()
+        getTransactions()
+        await getPrices()
+    }
 }

--- a/BDKSwiftExampleWallet/View/Home/ActivityHomeHeaderView.swift
+++ b/BDKSwiftExampleWallet/View/Home/ActivityHomeHeaderView.swift
@@ -18,6 +18,9 @@ struct ActivityHomeHeaderView: View {
     let isKyotoConnected: Bool
     let currentBlockHeight: UInt32
 
+    /// Optional retry action used for Kyoto errors.
+    let retryKyotoSync: (() -> Void)?
+
     let showAllTransactions: () -> Void
 
     var body: some View {
@@ -116,6 +119,13 @@ struct ActivityHomeHeaderView: View {
                     }
                 }
                 .contentTransition(.symbolEffect(.replace.offUp))
+                .contentShape(Rectangle())  // Expand tap target for retry on error
+                .onTapGesture {
+                    guard isKyotoClient else { return }
+                    if case .error = walletSyncState {
+                        retryKyotoSync?()
+                    }
+                }
 
             }
             .foregroundStyle(.secondary)

--- a/BDKSwiftExampleWallet/View/WalletView.swift
+++ b/BDKSwiftExampleWallet/View/WalletView.swift
@@ -54,7 +54,12 @@ struct WalletView: View {
                             needsFullScan: viewModel.needsFullScan,
                             isKyotoClient: viewModel.isKyotoClient,
                             isKyotoConnected: viewModel.isKyotoConnected,
-                            currentBlockHeight: viewModel.currentBlockHeight
+                            currentBlockHeight: viewModel.currentBlockHeight,
+                            retryKyotoSync: {
+                                Task {
+                                    await viewModel.retryKyotoSync()
+                                }
+                            }
                         ) {
                             showAllTransactions = true
                         }


### PR DESCRIPTION
<!-- Erase any parts of this template not applicable to your Pull Request. -->

### Description

Can see this person icon sometimes next to the green connected icon, which indicates connected but couldn't sync. Pull-to-refresh not hooked into this.

<img width="621" height="1344" alt="IMG_0512" src="https://github.com/user-attachments/assets/1b2b3d56-743c-48e7-ab00-d48bf149af29" />


### Notes to the reviewers

Might hook it into PullToRefresh instead with this other option https://github.com/bitcoindevkit/BDKSwiftExampleWallet/pull/344

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I have formatted my code with [swift-format](https://github.com/apple/swift-format) per `.swift-format` [file](https://github.com/reez/BDKSwiftExampleWallet/blob/main/.swift-format)

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] UI changes tested on small, medium, and large devices to ensure layout consistency

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
