### PR TITLE
Add weekly background Kyoto CBF sync task (#352)

### DIFF
--- a/BDKSwiftExampleWallet.xcodeproj/project.pbxproj
+++ b/BDKSwiftExampleWallet.xcodeproj/project.pbxproj
@@ -1071,7 +1071,7 @@
 			repositoryURL = "https://github.com/bitcoindevkit/bdk-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 2.3.0;
+				version = 2.3.1;
 			};
 		};
 		AF77B2222F4B2C9E00000002 /* XCRemoteSwiftPackageReference "CodeScanner" */ = {

--- a/BDKSwiftExampleWallet/App/BDKSwiftExampleWalletApp.swift
+++ b/BDKSwiftExampleWallet/App/BDKSwiftExampleWalletApp.swift
@@ -6,6 +6,7 @@
 //
 
 import BitcoinDevKit
+import BackgroundTasks
 import SwiftUI
 
 @main
@@ -13,6 +14,12 @@ struct BDKSwiftExampleWalletApp: App {
     @AppStorage("isOnboarding") var isOnboarding: Bool = true
     @State private var navigationPath = NavigationPath()
     @State private var refreshTrigger = UUID()
+    @Environment(\.scenePhase) private var scenePhase
+
+    init() {
+        BackgroundCBFSyncTask.register()
+        BackgroundCBFSyncTask.schedule()
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -30,6 +37,11 @@ struct BDKSwiftExampleWalletApp: App {
                 BDKClient.live.setNeedsFullScan(true)
                 navigationPath = NavigationPath()
             }
+            .onChange(of: scenePhase) { _, newValue in
+                if newValue == .background {
+                    BackgroundCBFSyncTask.schedule()
+                }
+            }
         }
     }
 }
@@ -40,5 +52,71 @@ extension BDKSwiftExampleWalletApp {
         let _ = refreshTrigger
         let _ = isOnboarding
         return (try? KeyClient.live.getBackupInfo()) != nil
+    }
+}
+
+private enum BackgroundCBFSyncTask {
+    static let identifier = "com.bitcoindevkit.bdkswiftexamplewallet.cbf-sync"
+    private static let minimumInterval: TimeInterval = 60 * 60 * 24 * 7
+
+    static func register() {
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: identifier,
+            using: nil
+        ) { task in
+            guard let processingTask = task as? BGProcessingTask else {
+                task.setTaskCompleted(success: false)
+                return
+            }
+            handle(processingTask)
+        }
+    }
+
+    static func schedule() {
+        let request = BGProcessingTaskRequest(identifier: identifier)
+        request.requiresNetworkConnectivity = true
+        request.requiresExternalPower = true
+        request.earliestBeginDate = Date(timeIntervalSinceNow: minimumInterval)
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+        } catch {
+            print("[BackgroundCBF] Failed to schedule task: \(error)")
+        }
+    }
+
+    private static func handle(_ task: BGProcessingTask) {
+        schedule()
+
+        let syncTask = Task.detached(priority: .background) {
+            do {
+                try await runKyotoSync()
+                task.setTaskCompleted(success: true)
+            } catch {
+                print("[BackgroundCBF] Background sync failed: \(error)")
+                task.setTaskCompleted(success: false)
+            }
+        }
+
+        task.expirationHandler = {
+            syncTask.cancel()
+        }
+    }
+
+    private static func runKyotoSync() async throws {
+        let bdkClient = BDKClient.live
+
+        guard (try? bdkClient.getBackupInfo()) != nil else {
+            return
+        }
+
+        try bdkClient.loadWallet()
+
+        guard bdkClient.getClientType() == .kyoto else {
+            return
+        }
+
+        let inspector = WalletSyncScriptInspector(updateProgress: { _, _ in })
+        try await bdkClient.syncWithInspector(inspector)
     }
 }

--- a/BDKSwiftExampleWallet/App/BDKSwiftExampleWalletApp.swift
+++ b/BDKSwiftExampleWallet/App/BDKSwiftExampleWalletApp.swift
@@ -59,6 +59,16 @@ private enum BackgroundCBFSyncTask {
     static let identifier = "com.bitcoindevkit.bdkswiftexamplewallet.cbf-sync"
     private static let minimumInterval: TimeInterval = 60 * 60 * 24 * 7
 
+    private actor TaskCompletionTracker {
+        private var didComplete = false
+
+        func complete(task: BGProcessingTask, success: Bool) {
+            guard !didComplete else { return }
+            didComplete = true
+            task.setTaskCompleted(success: success)
+        }
+    }
+
     static func register() {
         BGTaskScheduler.shared.register(
             forTaskWithIdentifier: identifier,
@@ -87,19 +97,23 @@ private enum BackgroundCBFSyncTask {
 
     private static func handle(_ task: BGProcessingTask) {
         schedule()
+        let completionTracker = TaskCompletionTracker()
 
         let syncTask = Task.detached(priority: .background) {
             do {
                 try await runKyotoSync()
-                task.setTaskCompleted(success: true)
+                await completionTracker.complete(task: task, success: true)
             } catch {
                 print("[BackgroundCBF] Background sync failed: \(error)")
-                task.setTaskCompleted(success: false)
+                await completionTracker.complete(task: task, success: false)
             }
         }
 
         task.expirationHandler = {
             syncTask.cancel()
+            Task {
+                await completionTracker.complete(task: task, success: false)
+            }
         }
     }
 

--- a/BDKSwiftExampleWallet/Info.plist
+++ b/BDKSwiftExampleWallet/Info.plist
@@ -2,9 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.bitcoindevkit.bdkswiftexamplewallet.cbf-sync</string>
+	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSPasteboardUsageDescription</key>
 	<string>"To allow users to copy and paste text between the app and other apps"</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>processing</string>
+	</array>
 </dict>
 </plist>

--- a/BDKSwiftExampleWallet/Service/Key Service/KeyService.swift
+++ b/BDKSwiftExampleWallet/Service/Key Service/KeyService.swift
@@ -16,7 +16,7 @@ private struct KeyService {
         let keychain = Keychain(service: "com.matthewramsden.bdkswiftexamplewallet.testservice")
             .label(Bundle.main.displayName)
             .synchronizable(false)
-            .accessibility(.whenUnlocked)
+            .accessibility(.afterFirstUnlock)
         self.keychain = keychain
     }
 


### PR DESCRIPTION
### Description

This PR implements the background CBF sync flow discussed in [#352](https://github.com/bitcoindevkit/BDKSwiftExampleWallet/issues/352).

In short, the app now registers a `BGProcessingTask` and schedules it to run roughly once a week (with network + external power requirements). When the task runs, it attempts to load the wallet and perform a Kyoto sync if the wallet exists and Kyoto is the selected backend.

I also added the required `Info.plist` entries for background processing and updated keychain accessibility to `.afterFirstUnlock` so background execution can still read wallet backup data while the device is locked.

### Notes to the reviewers

I kept this intentionally narrow to the core pieces needed for background sync:
- task registration/scheduling,
- task execution path,
- plist configuration,
- keychain accessibility prerequisite.

I did not add product-level logging in this PR, since #351 tracks that separately.

### Changelog notice

Add weekly background Kyoto CBF sync using `BGProcessingTask`, including required background task configuration and keychain access changes needed for locked-device execution.

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I have formatted my code with [swift-format](https://github.com/apple/swift-format) per `.swift-format` [file](https://github.com/reez/BDKSwiftExampleWallet/blob/main/.swift-format)

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] UI changes tested on small, medium, and large devices to ensure layout consistency

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
